### PR TITLE
Fixed the image preview for createIns page

### DIFF
--- a/scheduler/create_post/createIns.css
+++ b/scheduler/create_post/createIns.css
@@ -107,6 +107,7 @@ body {
     height: inherit;
     display: block;
     border-radius: 1vw;
+    object-fit: contain;
 }
 
 .text-container {

--- a/scheduler/edit_post/editPosts.css
+++ b/scheduler/edit_post/editPosts.css
@@ -109,6 +109,7 @@ body {
     height: inherit;
     display: block;
     border-radius: 1vw;
+    object-fit: contain;
 }
 
 .text-container {


### PR DESCRIPTION
Just added a line in createIns.css and it seems that landscape and portrait images conserve their ratios.